### PR TITLE
Portfolio fix mapping

### DIFF
--- a/Tutorials/Efficient Frontier with Quandl (Part 1).py
+++ b/Tutorials/Efficient Frontier with Quandl (Part 1).py
@@ -48,7 +48,7 @@ portfolio = {'Returns': port_returns,
              'Volatility': port_volatility}
 
 # extend original dictionary to accomodate each ticker and weight in the portfolio
-for counter,symbol in enumerate(selected):
+for counter,symbol in enumerate(cov_annual.columns):
     portfolio[symbol+' Weight'] = [Weight[counter] for Weight in stock_weights]
 
 # make a nice dataframe of the extended dictionary

--- a/Tutorials/Efficient Frontier with Sharpe Ratio.py
+++ b/Tutorials/Efficient Frontier with Sharpe Ratio.py
@@ -55,7 +55,7 @@ portfolio = {'Returns': port_returns,
              'Sharpe Ratio': sharpe_ratio}
 
 # extend original dictionary to accomodate each ticker and weight in the portfolio
-for counter,symbol in enumerate(selected):
+for counter,symbol in enumerate(cov_annual.columns):
     portfolio[symbol+' Weight'] = [Weight[counter] for Weight in stock_weights]
 
 # make a nice dataframe of the extended dictionary


### PR DESCRIPTION
Map Symbol+Weight portfolio keys to the correct array of stock weights. `selected` does not have the same order as that used in the pandas dataframe
https://medium.com/@troy.engelhardt/hey-just-letting-you-know-that-your-final-data-frame-labelled-df-is-in-fact-mislabelled-6861298efcda#--responses